### PR TITLE
Display tool call streaming progress in real-time

### DIFF
--- a/chatbot_tui/chatbot.css
+++ b/chatbot_tui/chatbot.css
@@ -40,3 +40,17 @@
     padding: 1 1;
   }
 }
+
+.message.tool_thinking #bubble {
+  background: $success-darken-2;
+  color: $text;
+  padding: 1 1;
+  border-left: thick $success;
+}
+
+.message.tool_status #bubble {
+  background: $warning-darken-2;
+  color: $text;
+  padding: 1 1;
+  border-left: thick $warning;
+}

--- a/chatbot_tui/widgets/message.py
+++ b/chatbot_tui/widgets/message.py
@@ -11,7 +11,7 @@ class Message(HorizontalGroup):
     role = reactive("assistant", recompose=True)
     message = reactive("", layout=True)
 
-    def __init__(self, message: str, *, role: Literal["user", "assistant", "tool_status"]) -> None:
+    def __init__(self, message: str, *, role: Literal["user", "assistant", "tool_status", "tool_thinking"]) -> None:
         super().__init__()
         self.role = role
         self.message = message
@@ -22,6 +22,7 @@ class Message(HorizontalGroup):
         self.set_class(self.role == "assistant", "assistant")
         self.set_class(self.role == "user", "user")
         self.set_class(self.role == "tool_status", "tool_status")
+        self.set_class(self.role == "tool_thinking", "tool_thinking")
 
     def compose(self) -> ComposeResult:
         if self.role == "user":
@@ -38,6 +39,9 @@ class Message(HorizontalGroup):
                 id="bubble",
                 markup=False,
             )
+        elif self.role == "tool_thinking":
+            # Use Markdown for tool_thinking to properly render code blocks
+            yield Markdown(self.message, id="bubble")
         else:
             raise ValueError(f"Invalid role: {self.role}")
 
@@ -45,7 +49,7 @@ class Message(HorizontalGroup):
         """Update the message content when the message changes."""
         if self.role == "user":
             self.query_one("#bubble", Static).update(message)
-        elif self.role == "assistant":
+        elif self.role in ["assistant", "tool_thinking"]:
             self.query_one("#bubble", Markdown).update(message)
         elif self.role == "tool_status":
             self.query_one("#bubble", Static).update(message)


### PR DESCRIPTION
## Description
This PR implements a feature to display thinking progress when a tool starts to stream in the chatbot TUI application. It specifically shows the tool call construction as it is being streamed rather than modifying the tools themselves.

## Changes
- Added tool_call_widgets dictionary to track active tool call widgets
- Modified Message widget to render tool_thinking messages with Markdown support
- Updated chat.py to display tool call construction in real-time
- Implemented JSON formatting for tool call arguments to improve readability
- Added CSS styling for tool_thinking messages

## Testing
The implementation can be tested by running the application and using tools that stream responses.